### PR TITLE
feat: Added support for basic authentication

### DIFF
--- a/strutil.py
+++ b/strutil.py
@@ -1,0 +1,2 @@
+def is_not_blank(string: str) -> bool:
+    return bool(string and string.strip())


### PR DESCRIPTION
This PR attempts to add a basic authentication feature in this module.

Usage:

```python
from config.spring import ConfigClient

c = ConfigClient(
  app_name="application"
  url="http://localhost:8888/application-dev.json",
  username="user",
  password="pass"
)

config = c.get_config()
```