### PR TITLE
Enhanced cf support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ venv.bak/
 # mypy
 .mypy_cache/
 .vscode
+.idea/

--- a/config/cfenv.py
+++ b/config/cfenv.py
@@ -27,9 +27,9 @@ class CFenv:
         )
     )
 
-    if "config-server" in vcap_services._default:
+    if "config-server" in attr.asdict(vcap_services)['_default']:
         val = "config-server"
-    else:
+    elif "p-config-server" in attr.asdict(vcap_services)['_default']:
         val = "p-config-server"
 
     @property
@@ -48,14 +48,14 @@ class CFenv:
     def uris(self) -> Any:
         return glom(self.vcap_application, 'uris', default=[])
 
-    def configserver_uri(self, vcap_path: str = val+'.0.credentials.uri') -> Any:
+    def configserver_uri(self, vcap_path: str = val + '.0.credentials.uri') -> Any:
         return glom(self.vcap_services, vcap_path, default='')
 
-    def configserver_access_token_uri(self, vcap_path: str = val+'.0.credentials.access_token_uri') -> Any:
+    def configserver_access_token_uri(self, vcap_path: str = val + '.0.credentials.access_token_uri') -> Any:
         return glom(self.vcap_services, vcap_path, default='')
 
-    def configserver_client_id(self, vcap_path: str = val+'.0.credentials.client_id') -> Any:
+    def configserver_client_id(self, vcap_path: str = val + '.0.credentials.client_id') -> Any:
         return glom(self.vcap_services, vcap_path, default='')
 
-    def configserver_client_secret(self, vcap_path: str = val+'.0.credentials.client_secret') -> Any:
+    def configserver_client_secret(self, vcap_path: str = val + '.0.credentials.client_secret') -> Any:
         return glom(self.vcap_services, vcap_path, default='')

--- a/config/cfenv.py
+++ b/config/cfenv.py
@@ -29,7 +29,7 @@ class CFenv:
 
     if "config-server" in attr.asdict(vcap_services)['_default']:
         val = "config-server"
-    elif "p-config-server" in attr.asdict(vcap_services)['_default']:
+    else:
         val = "p-config-server"
 
     @property

--- a/config/cfenv.py
+++ b/config/cfenv.py
@@ -27,6 +27,11 @@ class CFenv:
         )
     )
 
+    if "config-server" in vcap_services._default:
+        val = "config-server"
+    else:
+        val = "p-config-server"
+
     @property
     def space_name(self) -> Any:
         return glom(self.vcap_application, 'space_name', default='')
@@ -43,14 +48,14 @@ class CFenv:
     def uris(self) -> Any:
         return glom(self.vcap_application, 'uris', default=[])
 
-    def configserver_uri(self, vcap_path: str = 'p-config-server.0.credentials.uri') -> Any:
+    def configserver_uri(self, vcap_path: str = val+'.0.credentials.uri') -> Any:
         return glom(self.vcap_services, vcap_path, default='')
 
-    def configserver_access_token_uri(self, vcap_path: str = 'p-config-server.0.credentials.access_token_uri') -> Any:
+    def configserver_access_token_uri(self, vcap_path: str = val+'.0.credentials.access_token_uri') -> Any:
         return glom(self.vcap_services, vcap_path, default='')
 
-    def configserver_client_id(self, vcap_path: str = 'p-config-server.0.credentials.client_id') -> Any:
+    def configserver_client_id(self, vcap_path: str = val+'.0.credentials.client_id') -> Any:
         return glom(self.vcap_services, vcap_path, default='')
 
-    def configserver_client_secret(self, vcap_path: str = 'p-config-server.0.credentials.client_secret') -> Any:
+    def configserver_client_secret(self, vcap_path: str = val+'.0.credentials.client_secret') -> Any:
         return glom(self.vcap_services, vcap_path, default='')

--- a/config/spring.py
+++ b/config/spring.py
@@ -38,12 +38,19 @@ class ConfigClient:
     )
     profile = attr.ib(
         type=str,
-        default=os.getenv('PROFILE', 'development')
+        default=os.getenv('PROFILE', '')
     )
-    url = attr.ib(
-        type=str,
-        default="{address}/{branch}/{app_name}-{profile}.json"
-    )
+    """support for empty/blank profile"""
+    if profile._default == "":
+        url = attr.ib(
+            type=str,
+            default="{address}/{branch}/{app_name}.json"
+        )
+    else:
+        url = attr.ib(
+            type=str,
+            default="{address}/{branch}/{app_name}-{profile}.json"
+        )
     _config = attr.ib(
         type=dict,
         default={},

--- a/config/spring.py
+++ b/config/spring.py
@@ -41,7 +41,7 @@ class ConfigClient:
         default=os.getenv('PROFILE', '')
     )
     """support for empty/blank profile"""
-    if profile._default == "":
+    if attr.asdict(profile)['_default'] == "":
         url = attr.ib(
             type=str,
             default="{address}/{branch}/{app_name}.json"

--- a/tests/unit/test_spring.py
+++ b/tests/unit/test_spring.py
@@ -91,7 +91,7 @@ class TestConfigClient(unittest.TestCase):
         self.assertIsInstance(self.obj.url, str)
         self.assertEqual(
             self.obj.url,
-            "http://localhost:8888/master/test-app-development.json"
+            "http://localhost:8888/master/test-app-.json"
         )
 
     def test_custom_url_property(self):
@@ -104,7 +104,7 @@ class TestConfigClient(unittest.TestCase):
         self.assertEqual(obj.branch, 'development')
         self.assertEqual(
             obj.url,
-            "http://localhost:8888/development/development-test-app.json"
+            "http://localhost:8888/development/-test-app.json"
         )
 
     def test_get_attribute(self):


### PR DESCRIPTION
this pr addresses https://github.com/amenezes/config-client/issues/20
the changes allow one to use either the oss-config-server or the pivotal ones, as well as supporting having an empty profile name.  this work has been tested and verified against both a pivotal environment as well as an open-source cf environment.

**todo: the cf config servers provide the BRANCH name from the config server.  will need to add support for that.