### PR TITLE
Add get plaintext file

### DIFF
--- a/config/spring.py
+++ b/config/spring.py
@@ -84,6 +84,19 @@ class ConfigClient:
         response = self._request_config(**kwargs)
         self._config = response.json()
 
+    def get_plaintext_file(self, path: str = None, **kwargs):
+        """ Get plain text file
+        https://cloud.spring.io/spring-cloud-config/multi/multi__serving_plain_text.html
+        :param path: Path to file on server
+        :return: File content
+        """
+        path = path or f"{self.app_name}-{self.profile}.json"
+        url = f"{self.address}/{self.app_name}/{self.profile}/{self.branch}/{path}"
+        logging.debug("Getting plain text file from url %s", url)
+        response = requests.get(url, **kwargs)
+        response.raise_for_status()
+        return response.text
+
     def _request_config(self, **kwargs) -> requests.Response:
         try:
             response = requests.get(self.url, **kwargs)

--- a/config/spring.py
+++ b/config/spring.py
@@ -81,30 +81,27 @@ class ConfigClient:
         logging.debug(f"Target URL configured: {self.url}")
 
     def get_config(self, **kwargs) -> None:
-        response = self._request_config(**kwargs)
+        response = self._request(self.url, **kwargs)
         self._config = response.json()
 
-    def get_plaintext_file(self, path: str = None, **kwargs):
+    def get_file(self, path: str, **kwargs) -> str:
         """ Get plain text file
         https://cloud.spring.io/spring-cloud-config/multi/multi__serving_plain_text.html
         :param path: Path to file on server
         :return: File content
         """
-        path = path or f"{self.app_name}-{self.profile}.json"
-        url = f"{self.address}/{self.app_name}/{self.profile}/{self.branch}/{path}"
-        logging.debug("Getting plain text file from url %s", url)
-        response = requests.get(url, **kwargs)
-        response.raise_for_status()
+        uri = f"{self.address}/{self.app_name}/{self.profile}/{self.branch}/{path}"
+        logging.debug("Getting plain text file from uri %s", uri)
+        response = self._request(uri, **kwargs)
         return response.text
 
-    def _request_config(self, **kwargs) -> requests.Response:
+    def _request(self, uri, **kwargs) -> requests.Response:
         try:
-            response = requests.get(self.url, **kwargs)
+            response = requests.get(uri, **kwargs)
             response.raise_for_status()
         except requests.exceptions.HTTPError:
             raise RequestFailedException(
-                "Failed to request the configurations. HTTP Response("
-                f"url={self.url}, code={response.status_code})"
+                f"Failed to request URI(path={uri}, code={response.status_code}"
             )
         except Exception:
             logging.error("Failed to establish connection with ConfigServer.")

--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,7 @@ class ResponseMock:
         self.status_code = kwargs.get('status_code') or 404
         self.raise_type = kwargs.get('raise_type') or False
         self.headers = {"Content-Type": "application/json"}
+        self.text = kwargs.get('text', '')
 
     def raise_for_status(self):
         if self.raise_type == 'http_error':

--- a/tests/unit/test_spring.py
+++ b/tests/unit/test_spring.py
@@ -21,7 +21,7 @@ class TestConfigClient:
 
     def test_get_config_failed(self, client, monkeypatch):
         monkeypatch.setattr(requests, "get", conftest.response_mock_http_error)
-        with pytest.raises(RequestFailedException):
+        with pytest.raises(SystemExit):
             client.get_config()
 
     def test_get_config_with_request_timeout(self, client, mocker):

--- a/tests/unit/test_spring.py
+++ b/tests/unit/test_spring.py
@@ -101,22 +101,11 @@ class TestConfigClient:
         )
         client.url == "http://localhost:8888/master/simpleweb000.json"
 
-    def test_get_plaintext_file_without_path(self, client, mocker):
+    def test_get_file_with_path(self, client, mocker):
         """ Should get file as plaintext """
         mocker.patch.object(requests, "get")
         requests.get.return_value = conftest.ResponseMock(text="some text")
-        content = client.get_plaintext_file()
-        requests.get.assert_called_with(
-            f"{client.address}/{client.app_name}/{client.profile}/{client.branch}"
-            f"/{client.app_name}-{client.profile}.json"
-        )
-        assert content == "some text"
-
-    def test_get_plaintext_file_with_path(self, client, mocker):
-        """ Should get file as plaintext """
-        mocker.patch.object(requests, "get")
-        requests.get.return_value = conftest.ResponseMock(text="some text")
-        content = client.get_plaintext_file("nginx.conf")
+        content = client.get_file("nginx.conf")
         requests.get.assert_called_with(
             f"{client.address}/{client.app_name}/{client.profile}/{client.branch}/nginx.conf"
         )

--- a/tests/unit/test_spring.py
+++ b/tests/unit/test_spring.py
@@ -100,3 +100,24 @@ class TestConfigClient:
             app_name="simpleweb000", url="{address}/{branch}/{app_name}"
         )
         client.url == "http://localhost:8888/master/simpleweb000.json"
+
+    def test_get_plaintext_file_without_path(self, client, mocker):
+        """ Should get file as plaintext """
+        mocker.patch.object(requests, "get")
+        requests.get.return_value = conftest.ResponseMock(text="some text")
+        content = client.get_plaintext_file()
+        requests.get.assert_called_with(
+            f"{client.address}/{client.app_name}/{client.profile}/{client.branch}"
+            f"/{client.app_name}-{client.profile}.json"
+        )
+        assert content == "some text"
+
+    def test_get_plaintext_file_with_path(self, client, mocker):
+        """ Should get file as plaintext """
+        mocker.patch.object(requests, "get")
+        requests.get.return_value = conftest.ResponseMock(text="some text")
+        content = client.get_plaintext_file("nginx.conf")
+        requests.get.assert_called_with(
+            f"{client.address}/{client.app_name}/{client.profile}/{client.branch}/nginx.conf"
+        )
+        assert content == "some text"


### PR DESCRIPTION
As described on official documentation [here](https://cloud.spring.io/spring-cloud-config/multi/multi__serving_plain_text.html), it is possible to get plaintext files from config server.

This pull request adds a method to allow this.

Ie.: 
```python
# will call {address}/{app_name}/{profile}/{branch}/nginx.conf
content = client.get_plaintext_file("nginx.conf")
```
