### PR TITLE
added handling child lists

### DIFF
--- a/config/_config.py
+++ b/config/_config.py
@@ -43,12 +43,19 @@ def merge_list(config: dict) -> None:
 
     for key, it in keys.items():
         for i in range(it + 1):
+            value = config[f"{key}[{i}]"]
             if key not in config:
-                config.update({key: [config[f"{key}[{i}]"]]})
+                config.update({key: [value]})
                 config.pop(f"{key}[{i}]")
             else:
-                config[key].append(config[f"{key}[{i}]"])
+                config[key].append(value)
                 config.pop(f"{key}[{i}]")
+
+
+def _fix_list_items(values: list) -> None:
+    for item in values:
+        if isinstance(item, dict):
+            _merge(item)
 
 
 def _merge(config: dict) -> None:
@@ -57,6 +64,8 @@ def _merge(config: dict) -> None:
         merge_list(config[k])
         if isinstance(v, dict):
             _merge(v)
+        elif isinstance(v, list):
+            _fix_list_items(v)
 
 
 def _fix_key(key_str: str) -> Tuple[str, bool]:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -46,6 +46,14 @@ from config._config import merge_dict, merge_list, to_dict
             {"examples.three.one[0]": "one", "examples.three.one[1]": "thow"},
             {"examples": {"three": {"one": ["one", "thow"]}}},
         ),
+        (
+            {
+                "main_list[0]": {"child_list[0]": {"property-name": "example0"}},
+            },
+            {
+                "main_list": [{'child_list': [{'property-name': 'example0'}]}],
+            },
+        ),
     ],
 )
 def test_to_dict(data, expected):


### PR DESCRIPTION
For now, the library does not parse child lists and leave them in this format:
```
{'main_list': [{'child_list[0]': {'property-name': 'example0'}, 'child_list[1]': {'property-name': 'example1'}}]}
```
This PR will change the result dictionary to the next format:
```
{'main_list': [{'child_list': [{'property-name': 'example0'}, {'property-name': 'example1'}]}
```